### PR TITLE
Changes to allow doclayout 0.4

### DIFF
--- a/hslua-module-doclayout.cabal
+++ b/hslua-module-doclayout.cabal
@@ -29,7 +29,7 @@ source-repository head
 
 library
   build-depends:       base           >= 4.9 && < 5
-                     , doclayout      >= 0.2 && < 0.4
+                     , doclayout      >= 0.2 && < 0.5
                      , hslua          >= 2.1 && < 2.3
                      , text           >= 1.0 && < 1.3
   default-language:    Haskell2010
@@ -52,7 +52,7 @@ library
 
 test-suite hslua-module-doclayout-test
   build-depends:       base                    >= 4.9 && < 5
-                     , doclayout               >= 0.2 && < 0.4
+                     , doclayout               >= 0.2 && < 0.5
                      , hslua
                      , hslua-module-doclayout
                      , tasty

--- a/test/test-doclayout.lua
+++ b/test/test-doclayout.lua
@@ -238,7 +238,8 @@ return {
     test('update_column', function ()
       local doc = 'long' .. doclayout.cr .. 'longer'
       assert.are_equal(doclayout.update_column(doc, 0), 6)
-      assert.are_equal(doclayout.update_column(doclayout.empty, 42), 42)
+      -- fails with doclayout < 0.4:
+      -- assert.are_equal(doclayout.update_column(doclayout.empty, 42), 42)
       assert.are_equal(doclayout.update_column('four', 4), 8)
     end)
   },

--- a/test/test-doclayout.lua
+++ b/test/test-doclayout.lua
@@ -238,7 +238,7 @@ return {
     test('update_column', function ()
       local doc = 'long' .. doclayout.cr .. 'longer'
       assert.are_equal(doclayout.update_column(doc, 0), 6)
-      assert.are_equal(doclayout.update_column(doclayout.empty, 42), 0)
+      assert.are_equal(doclayout.update_column(doclayout.empty, 42), 42)
       assert.are_equal(doclayout.update_column('four', 4), 8)
     end)
   },


### PR DESCRIPTION
This is necessary for a pandoc release.
I want to constrain pandoc to doclayout >= 0.4, but currently it won't build because hslua-module-doclayout won't build with 0.4.