### PR TITLE
Allow doclayout 0.5.

### DIFF
--- a/hslua-module-doclayout.cabal
+++ b/hslua-module-doclayout.cabal
@@ -31,7 +31,7 @@ source-repository head
 
 common common-options
   build-depends:       base              >= 4.11   && < 5
-                     , doclayout         >= 0.2    && < 0.5
+                     , doclayout         >= 0.2    && < 0.6
                      , hslua             >= 2.3    && < 2.4
                      , text              >= 1.2    && < 2.2
 


### PR DESCRIPTION
Note:  we don't include bindings to the new functions from doclayout 0.5.  Maybe it's not necessary, but if we did we'd need a lower bound too.  0.5 introduces `renderANSI` and functions to add ANSI styling, like `link`, `green`, `bold`.